### PR TITLE
Fix the composer provide rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "spryker/code-sniffer": "^0.12.4 || ^0.14.0"
     },
     "provide": {
-        "psr/http-client": "^1.0"
+        "psr/http-client-implementation": "1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package does not contain the source code of the psr/http-client interfaces, and so it does not provide the psr/http-client package. What is provided is a class implementing the interface.

On a side note, seeing the same package in require and provide is a strong sign of something going wrong.
Refs composer/composer#9308